### PR TITLE
res.send(status) is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = function(options) {
       res.set('Access-Control-Allow-Credentials', 'true')
     }
 
-    if ('OPTIONS' == req.method) return res.send(200)
+    if ('OPTIONS' == req.method) return res.sendStatus(200)
     next()
   }
 }


### PR DESCRIPTION
res.send(status) is deprecated use res.sendStatus(status) instead.